### PR TITLE
Evade SASS compression on build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           export JEKYLL_ENV=production
-          bundle exec jekyll build
+          bundle exec jekyll build --profile
       - name: Purge unused CSS 🧹
         run: |
           npm install -g purgecss

--- a/_config.yml
+++ b/_config.yml
@@ -279,7 +279,8 @@ defaults:
       sitemap: false
 
 sass:
-  style: compressed
+  style: expanded # compressed # <-- much slower
+  sourcemap: development
 
 # -----------------------------------------------------------------------------
 # Jekyll Minifier


### PR DESCRIPTION
Last few minutes seems to be SASS compression of styling. Avoiding to improve build and deploy speeds.